### PR TITLE
Improve frontend workflows and seed dev test accounts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install frontend dependencies
         working-directory: front-end
-        run: npm ci
+        run: npm install
 
       - name: Build frontend for production
         working-directory: front-end

--- a/README.md
+++ b/README.md
@@ -34,6 +34,22 @@ cd san11-platform
 make deploy-dev
 ```
 
+## Development test accounts
+
+The DEV backend seeds deterministic accounts at startup so local manual checks
+and browser automation can cover common permission paths without private
+credentials. These credentials are only configured for the DEV environment.
+
+| Role | Username | Email | Password | Main coverage |
+| --- | --- | --- | --- | --- |
+| Admin | `dev_admin` | `dev-admin@san11.local` | `devpass` | Review queue, moderation, admin-only actions |
+| Package author | `dev_author` | `dev-author@san11.local` | `devpass` | Author tools, resource editing, screenshot/version workflows |
+| Regular user | `dev_user` | `dev-user@san11.local` | `devpass` | Browse, collect, subscribe, comment as a normal user |
+
+The author account owns the seeded package `categories/1/packages/910001`. The
+local login page also shows quick-fill buttons for these accounts when using the
+default development frontend environment.
+
 ## Tests
 ```sh
 make test

--- a/back-end/src/app/dev_seed.py
+++ b/back-end/src/app/dev_seed.py
@@ -1,0 +1,133 @@
+import logging
+import os
+from dataclasses import dataclass
+
+from app.protos import san11_platform_pb2 as pb
+from core.auth.user_util import hash_password
+from core.common.env import Env, get_env
+from core.time_util import get_now
+from models.model_package import ModelPackage
+from models.model_user import DEFAULT_USER_AVATAR, ModelUser, default_user_settings
+from repositories.resource_repository import ResourceRepository, repository_for
+
+logger = logging.getLogger(os.path.basename(__file__))
+
+DEV_ACCOUNT_PASSWORD = 'devpass'
+
+
+@dataclass(frozen=True)
+class DevAccount:
+    user_id: int
+    username: str
+    email: str
+    user_type: int
+    website: str
+
+
+DEV_ACCOUNTS = (
+    DevAccount(
+        user_id=910001,
+        username='dev_admin',
+        email='dev-admin@san11.local',
+        user_type=pb.User.ADMIN,
+        website='https://san11.local/dev-admin',
+    ),
+    DevAccount(
+        user_id=910002,
+        username='dev_author',
+        email='dev-author@san11.local',
+        user_type=pb.User.REGULAR,
+        website='https://san11.local/dev-author',
+    ),
+    DevAccount(
+        user_id=910003,
+        username='dev_user',
+        email='dev-user@san11.local',
+        user_type=pb.User.REGULAR,
+        website='https://san11.local/dev-user',
+    ),
+)
+
+DEV_AUTHOR_PACKAGE_ID = 910001
+DEV_AUTHOR_PACKAGE_NAME = f'categories/1/packages/{DEV_AUTHOR_PACKAGE_ID}'
+
+def seed_dev_data() -> None:
+    if get_env() != Env.DEV:
+        return
+
+    logger.info('Seeding deterministic DEV users and author package.')
+    for account in DEV_ACCOUNTS:
+        _upsert_dev_account(account)
+    _upsert_dev_author_package()
+
+
+def _upsert_dev_account(account: DevAccount) -> None:
+    repository: ResourceRepository[ModelUser] = repository_for(ModelUser)
+    name = f'users/{account.user_id}'
+    now = get_now()
+    user = ModelUser(
+        name=name,
+        username=account.username,
+        email=account.email,
+        type=account.user_type,
+        image_url=DEFAULT_USER_AVATAR,
+        website=account.website,
+        hashed_password=hash_password(DEV_ACCOUNT_PASSWORD),
+        subscriber_count=0,
+        create_time=now,
+        update_time=now,
+        settings=default_user_settings(),
+    )
+
+    if repository.exists(name):
+        existing = repository.get(name)
+        user.create_time = existing.create_time
+        repository.update(user, update_update_time=False)
+        logger.info('Updated DEV account %s (%s).', account.username, name)
+        return
+
+    repository._create(parent='', resource=user, resource_id=account.user_id)
+    logger.info('Created DEV account %s (%s).', account.username, name)
+
+
+def _upsert_dev_author_package() -> None:
+    repository: ResourceRepository[ModelPackage] = repository_for(ModelPackage)
+    now = get_now()
+    package = ModelPackage(
+        name=DEV_AUTHOR_PACKAGE_NAME,
+        package_name='DEV 作者测试资源',
+        description=(
+            '<p>这是开发环境自动创建的作者测试资源，用来验证作者工具、'
+            '截图管理、介绍编辑、版本发布和资源状态相关界面。</p>'
+        ),
+        create_time=now,
+        update_time=now,
+        state=pb.NORMAL,
+        author_id=910002,
+        image_urls=[],
+        tags=[],
+        download_count=0,
+        like_count=0,
+        dislike_count=0,
+        subscriber_count=0,
+    )
+
+    if repository.exists(DEV_AUTHOR_PACKAGE_NAME):
+        existing = repository.get(DEV_AUTHOR_PACKAGE_NAME)
+        package.create_time = existing.create_time
+        package.image_urls = existing.image_urls
+        package.tags = existing.tags
+        package.download_count = existing.download_count
+        package.like_count = existing.like_count
+        package.dislike_count = existing.dislike_count
+        package.subscriber_count = existing.subscriber_count
+        repository.update(package, update_update_time=False)
+        logger.info('Updated DEV author package %s.', DEV_AUTHOR_PACKAGE_NAME)
+        return
+
+    repository._create(
+        parent='categories/1',
+        resource=package,
+        resource_id=DEV_AUTHOR_PACKAGE_ID,
+    )
+    logger.info('Created DEV author package %s.', DEV_AUTHOR_PACKAGE_NAME)

--- a/back-end/src/app/dev_seed_test.py
+++ b/back-end/src/app/dev_seed_test.py
@@ -1,0 +1,33 @@
+import unittest
+from unittest import mock
+
+from app import dev_seed
+from core.common.env import Env
+
+
+class DevSeedTest(unittest.TestCase):
+    def test_seed_dev_data_is_disabled_outside_dev(self):
+        with mock.patch.object(dev_seed, 'get_env', return_value=Env.PROD), \
+             mock.patch.object(dev_seed, '_upsert_dev_account') as upsert_account, \
+             mock.patch.object(dev_seed, '_upsert_dev_author_package') as upsert_package:
+            dev_seed.seed_dev_data()
+
+        upsert_account.assert_not_called()
+        upsert_package.assert_not_called()
+
+    def test_seed_dev_data_creates_expected_dev_principals(self):
+        with mock.patch.object(dev_seed, 'get_env', return_value=Env.DEV), \
+             mock.patch.object(dev_seed, '_upsert_dev_account') as upsert_account, \
+             mock.patch.object(dev_seed, '_upsert_dev_author_package') as upsert_package:
+            dev_seed.seed_dev_data()
+
+        self.assertEqual(3, upsert_account.call_count)
+        self.assertEqual(
+            ['dev_admin', 'dev_author', 'dev_user'],
+            [call.args[0].username for call in upsert_account.call_args_list],
+        )
+        upsert_package.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/back-end/src/app/san11_platform_server.py
+++ b/back-end/src/app/san11_platform_server.py
@@ -9,6 +9,7 @@ import grpc
 from google.cloud import logging as cloud_logging
 
 from core.common.env import is_prod
+from app.dev_seed import seed_dev_data
 from app.grpc_service_registration import register_san11_platform_servicer
 from app.san11_platform_servicer import San11PlatformServicer
 from app.service_dependencies import San11PlatformDependencies
@@ -30,6 +31,7 @@ def create_server(
 
 
 def serve(address: str = DEFAULT_ADDRESS) -> None:
+    seed_dev_data()
     server = create_server()
     server.add_insecure_port(address)
     server.start()

--- a/front-end/src/app/account-management/signin/signin.component.css
+++ b/front-end/src/app/account-management/signin/signin.component.css
@@ -46,6 +46,98 @@ app-signin .auth-form {
     width: 100%;
 }
 
+app-signin .dev-account-panel {
+    display: grid;
+    gap: 12px;
+    margin-bottom: 18px;
+    padding: 14px;
+    border: 1px solid rgba(37, 99, 235, .18);
+    border-radius: var(--radius-md);
+    background:
+        linear-gradient(135deg, rgba(37, 99, 235, .07), rgba(255, 255, 255, .94) 62%),
+        var(--surface);
+}
+
+app-signin .dev-account-heading {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+}
+
+app-signin .dev-account-heading mat-icon {
+    display: inline-flex;
+    width: 32px;
+    height: 32px;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    border-radius: 10px;
+    background: var(--primary-soft);
+    color: var(--primary-color);
+    font-size: 19px;
+}
+
+app-signin .dev-account-heading div {
+    display: grid;
+    gap: 2px;
+    min-width: 0;
+}
+
+app-signin .dev-account-heading strong {
+    color: var(--text-color);
+    font-size: .95rem;
+    font-weight: 850;
+}
+
+app-signin .dev-account-heading span {
+    color: var(--text-muted);
+    font-size: .82rem;
+    line-height: 1.45;
+}
+
+app-signin .dev-account-grid {
+    display: grid;
+    gap: 8px;
+}
+
+app-signin .dev-account-button {
+    display: grid;
+    gap: 3px;
+    width: 100%;
+    padding: 10px 12px;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    background: rgba(255, 255, 255, .82);
+    color: var(--text-color);
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+    transition: border-color var(--animation-duration), background-color var(--animation-duration), transform var(--animation-duration);
+}
+
+app-signin .dev-account-button:hover {
+    border-color: rgba(37, 99, 235, .3);
+    background: #fff;
+    transform: translateY(-1px);
+}
+
+app-signin .dev-account-button strong {
+    font-size: .9rem;
+    font-weight: 850;
+}
+
+app-signin .dev-account-button span {
+    color: var(--primary-strong);
+    font-size: .84rem;
+    font-weight: 800;
+}
+
+app-signin .dev-account-button small {
+    color: var(--text-muted);
+    font-size: .78rem;
+    line-height: 1.35;
+}
+
 app-signin .field-stack {
     display: grid;
     gap: 12px;

--- a/front-end/src/app/account-management/signin/signin.component.html
+++ b/front-end/src/app/account-management/signin/signin.component.html
@@ -12,6 +12,24 @@
         <mat-tab-group #tagGroup [(selectedIndex)]="selectedTabIndex" class="header-less-tabs">
             <mat-tab label="login">
                 <form class="auth-form" #signInForm='ngForm' (ngSubmit)="onSignIn(signInForm.value)">
+                    <div *ngIf="devAccounts.length" class="dev-account-panel">
+                        <div class="dev-account-heading">
+                            <mat-icon>science</mat-icon>
+                            <div>
+                                <strong>开发测试账号</strong>
+                                <span>仅本地 dev 环境显示，点击后填入登录表单。</span>
+                            </div>
+                        </div>
+                        <div class="dev-account-grid">
+                            <button *ngFor="let account of devAccounts" type="button"
+                                class="dev-account-button" (click)="fillDevAccount(account, signInForm)">
+                                <strong>{{account.label}}</strong>
+                                <span>{{account.identity}} / {{account.password}}</span>
+                                <small>{{account.note}}</small>
+                            </button>
+                        </div>
+                    </div>
+
                     <div class="field-stack">
                         <mat-form-field appearance="outline">
                             <mat-label>用户名/邮箱</mat-label>

--- a/front-end/src/app/account-management/signin/signin.component.ts
+++ b/front-end/src/app/account-management/signin/signin.component.ts
@@ -8,6 +8,7 @@ import { Empty, SendVerificationCodeRequest, SignInRequest, UpdatePasswordReques
 import { NotificationService } from "../../common/notification.service";
 import { San11PlatformServiceService } from '../../service/san11-platform-service.service';
 import { saveUser } from '../../utils/user_util';
+import { environment } from '../../../environments/environment';
 
 
 
@@ -34,6 +35,7 @@ export class SigninComponent implements OnInit {
   resetPasswordForm: FormGroup;
 
   hidePassword = true;
+  devAccounts = environment.devAccounts || [];
 
   constructor(
     private notificationService: NotificationService,
@@ -109,6 +111,13 @@ export class SigninComponent implements OnInit {
         this.notificationService.warn(`登录失败: ${error.statusMessage}`);
       }
     );
+  }
+
+  fillDevAccount(account, signInForm) {
+    signInForm.form.patchValue({
+      identity: account.identity,
+      password: account.password,
+    });
   }
 
   onForgetPasswordClick() {

--- a/front-end/src/app/forum/article/article-detail/article-detail.component.css
+++ b/front-end/src/app/forum/article/article-detail/article-detail.component.css
@@ -165,6 +165,13 @@
     transform: translateY(0);
 }
 
+.title-edit-shell-author:hover .inline-edit-cue-suppressed,
+.title-edit-shell-author:focus-within .inline-edit-cue-suppressed,
+.inline-edit-cue-suppressed {
+    opacity: 0;
+    transform: translateY(2px);
+}
+
 .author-editable-title:focus-visible {
     outline: none;
     box-shadow: 0 0 0 4px rgba(37, 99, 235, .12);

--- a/front-end/src/app/forum/article/article-detail/article-detail.component.html
+++ b/front-end/src/app/forum/article/article-detail/article-detail.component.html
@@ -21,8 +21,8 @@
                             (click)="onTitleClick()" (keydown.enter)="onTitleEnter($event)" (input)="onTitleChange()">
                             {{article.subject}}
                         </h1>
-                        <span *ngIf="isAuthor() && editingTarget !== 'content'" class="inline-edit-cue"
-                            aria-hidden="true">
+                        <span *ngIf="isAuthor()" class="inline-edit-cue"
+                            [class.inline-edit-cue-suppressed]="editingTarget === 'content'" aria-hidden="true">
                             <mat-icon>edit</mat-icon>
                         </span>
                     </div>

--- a/front-end/src/app/package-management/package-detail/package-detail.component.css
+++ b/front-end/src/app/package-management/package-detail/package-detail.component.css
@@ -645,6 +645,56 @@
     border-radius: var(--radius-md);
 }
 
+.maintenance-card {
+    display: grid;
+    gap: 13px;
+    padding: 15px;
+    border-radius: var(--radius-md);
+}
+
+.maintenance-score {
+    display: inline-flex;
+    align-items: center;
+    min-height: 24px;
+    padding: 0 8px;
+    border-radius: 999px;
+    background: rgba(37, 99, 235, .1);
+    color: var(--primary-strong);
+    font-size: .74rem;
+    font-weight: 850;
+}
+
+.maintenance-list {
+    display: grid;
+    gap: 8px;
+}
+
+.maintenance-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 34px;
+    padding: 0 10px;
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, .72);
+    color: var(--text-muted);
+    font-size: .83rem;
+    font-weight: 800;
+}
+
+.maintenance-item mat-icon {
+    width: 18px;
+    height: 18px;
+    font-size: 18px;
+}
+
+.maintenance-item-done {
+    border-color: rgba(5, 150, 105, .18);
+    background: rgba(5, 150, 105, .08);
+    color: #047857;
+}
+
 .role-workspace {
     margin: 0;
     order: 1;

--- a/front-end/src/app/package-management/package-detail/package-detail.component.html
+++ b/front-end/src/app/package-management/package-detail/package-detail.component.html
@@ -266,6 +266,24 @@
                 </section>
 
                 <section *ngIf="isAuthor()"
+                    class="maintenance-card permission-surface permission-author-surface surface-panel app-detail-section">
+                    <div class="detail-card-heading">
+                        <div class="detail-card-title-row">
+                            <h2 class="detail-card-title">资源健康度</h2>
+                            <span class="maintenance-score">{{maintenanceHealthText}}</span>
+                        </div>
+                        <p>优先补齐会影响用户判断和下载信心的内容。</p>
+                    </div>
+                    <div class="maintenance-list">
+                        <div *ngFor="let item of maintenanceItems" class="maintenance-item"
+                            [class.maintenance-item-done]="item.done">
+                            <mat-icon>{{item.done ? 'check_circle' : item.icon}}</mat-icon>
+                            <span>{{item.text}}</span>
+                        </div>
+                    </div>
+                </section>
+
+                <section *ngIf="isAuthor()"
                     class="author-workspace role-workspace permission-surface permission-author-surface surface-panel app-detail-section">
                     <div class="detail-card-heading">
                         <div class="detail-card-title-row">

--- a/front-end/src/app/package-management/package-detail/package-detail.component.ts
+++ b/front-end/src/app/package-management/package-detail/package-detail.component.ts
@@ -215,6 +215,38 @@ export class PackageDetailComponent implements OnInit, OnDestroy {
     return this.allTags.filter(tag => !this.package.tags.some(selected => selected.name === tag.name));
   }
 
+  get maintenanceItems(): { icon: string; text: string; done: boolean }[] {
+    return [
+      {
+        icon: 'image',
+        text: '截图和封面',
+        done: (this.package?.imageUrls?.length || 0) > 0,
+      },
+      {
+        icon: 'description',
+        text: '资源介绍',
+        done: this.descriptionText.length >= 80,
+      },
+      {
+        icon: 'sell',
+        text: '标签',
+        done: (this.package?.tags?.length || 0) > 0,
+      },
+    ];
+  }
+
+  get maintenanceCompleteCount(): number {
+    return this.maintenanceItems.filter(item => item.done).length;
+  }
+
+  get maintenanceHealthText(): string {
+    if (this.maintenanceCompleteCount === this.maintenanceItems.length) {
+      return '资料完整';
+    }
+
+    return `${this.maintenanceCompleteCount}/${this.maintenanceItems.length} 项完成`;
+  }
+
   private get descriptionText(): string {
     return (this.package?.description ?? '')
       .replace(/<[^>]*>/g, '')

--- a/front-end/src/app/package-management/version-management/version-panel/branch/branch.component.ts
+++ b/front-end/src/app/package-management/version-management/version-panel/branch/branch.component.ts
@@ -55,7 +55,7 @@ export class BranchComponent {
     }
 
     ngOnInit(): void {
-        this.dataSource = new MatTableDataSource(this.branch.binaries);
+        this.dataSource = new MatTableDataSource(this.historicalBinaries);
     }
 
     ngAfterViewInit() {
@@ -64,6 +64,41 @@ export class BranchComponent {
 
     getVersionStr(binary: Binary): string {
         return version2str(binary.version);
+    }
+
+    get recommendedBinary(): Binary | undefined {
+        return this.branch?.binaries?.[0];
+    }
+
+    get historicalBinaries(): Binary[] {
+        return this.branch?.binaries?.slice(1) || [];
+    }
+
+    get hasHistory(): boolean {
+        return this.historicalBinaries.length > 0;
+    }
+
+    getDownloadLabel(binary: Binary): string {
+        if (binary?.file) {
+            return '下载推荐版本';
+        }
+        if (binary?.cloudDiskFile) {
+            return '打开网盘下载';
+        }
+        if (binary?.downloadMethod) {
+            return '查看下载方式';
+        }
+        return '查看版本';
+    }
+
+    getDownloadIcon(binary: Binary): string {
+        if (binary?.cloudDiskFile) {
+            return 'cloud_download';
+        }
+        if (binary?.downloadMethod) {
+            return 'info';
+        }
+        return 'download';
     }
 
 

--- a/front-end/src/app/package-management/version-management/version-panel/branch/branch.css
+++ b/front-end/src/app/package-management/version-management/version-panel/branch/branch.css
@@ -2,6 +2,86 @@
     overflow-x: auto;
 }
 
+.recommended-version {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 18px;
+    align-items: center;
+    margin: 18px;
+    padding: 18px;
+    border: 1px solid rgba(37, 99, 235, .18);
+    border-radius: var(--radius-lg);
+    background:
+        linear-gradient(135deg, rgba(37, 99, 235, .08), rgba(255, 255, 255, .96) 58%),
+        var(--surface);
+}
+
+.recommended-version-copy {
+    min-width: 0;
+}
+
+.recommended-kicker {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--primary-strong);
+    font-size: .82rem;
+    font-weight: 850;
+}
+
+.recommended-kicker mat-icon {
+    width: 18px;
+    height: 18px;
+    font-size: 18px;
+}
+
+.recommended-version h3 {
+    margin: 8px 0 12px;
+    color: var(--text-color);
+    font-size: 1.45rem;
+    line-height: 1.15;
+    font-weight: 900;
+}
+
+.recommended-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.recommended-actions {
+    display: flex;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: 10px;
+    max-width: 340px;
+}
+
+.recommended-download {
+    min-height: 42px;
+}
+
+.history-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 0 18px 12px;
+}
+
+.history-header h3 {
+    margin: 0;
+    color: var(--text-color);
+    font-size: 1rem;
+    font-weight: 850;
+}
+
+.history-header span {
+    color: var(--text-muted);
+    font-size: .84rem;
+    font-weight: 750;
+}
+
 .version-table {
     min-width: 720px;
 }
@@ -98,6 +178,11 @@
     font-weight: 750;
 }
 
+.empty-branch span {
+    color: var(--text-muted);
+    font-size: .9rem;
+}
+
 @media (max-width: 40rem) {
     :host {
         display: block;
@@ -105,6 +190,17 @@
 
     .actions-cell {
         width: 310px;
+    }
+
+    .recommended-version {
+        grid-template-columns: 1fr;
+        margin: 14px;
+        padding: 14px;
+    }
+
+    .recommended-actions {
+        justify-content: stretch;
+        max-width: none;
     }
 
     .action-cluster {

--- a/front-end/src/app/package-management/version-management/version-panel/branch/branch.html
+++ b/front-end/src/app/package-management/version-management/version-panel/branch/branch.html
@@ -1,5 +1,52 @@
 <div class="branch-panel" *ngIf="branch.binaries.length > 0; else emptyBranch">
-    <table mat-table [dataSource]="dataSource" class="version-table app-data-table">
+    <section class="recommended-version" *ngIf="recommendedBinary as binary">
+        <div class="recommended-version-copy">
+            <span class="recommended-kicker">
+                <mat-icon>verified</mat-icon>
+                推荐版本
+            </span>
+            <h3>{{this.getVersionStr(binary)}}</h3>
+            <div class="recommended-meta">
+                <span class="meta-pill">
+                    <mat-icon>schedule</mat-icon>
+                    {{binary.createTime}}
+                </span>
+                <span class="meta-pill">
+                    <mat-icon>inventory_2</mat-icon>
+                    {{binary.size || '未知大小'}}
+                </span>
+                <span class="meta-pill">
+                    <mat-icon>download</mat-icon>
+                    {{binary.downloadCount || 0}} 次
+                </span>
+            </div>
+        </div>
+        <div class="recommended-actions">
+            <button mat-flat-button color="primary" (click)="onDownload(binary)"
+                class="action-button action-primary recommended-download">
+                <mat-icon>{{getDownloadIcon(binary)}}</mat-icon>
+                <span>{{getDownloadLabel(binary)}}</span>
+            </button>
+            <button mat-stroked-button class="action-button action-secondary" type="button"
+                (click)="onDescription(binary)">
+                <mat-icon>description</mat-icon>
+                更新日志
+            </button>
+            <button *ngIf="binary.cloudDiskFile?.code" mat-stroked-button
+                class="action-button action-secondary" type="button"
+                (click)="copyCloudDiskCode(binary)">
+                <mat-icon>content_copy</mat-icon>
+                复制密码
+            </button>
+        </div>
+    </section>
+
+    <div class="history-header" *ngIf="hasHistory">
+        <h3>历史版本</h3>
+        <span>{{historicalBinaries.length}} 个版本</span>
+    </div>
+
+    <table *ngIf="hasHistory" mat-table [dataSource]="dataSource" class="version-table app-data-table">
         <ng-container matColumnDef="version">
             <th mat-header-cell *matHeaderCellDef> 版本 </th>
             <td mat-cell *matCellDef="let binary" class="version-column-cell">
@@ -79,12 +126,13 @@
         <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
         <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
     </table>
-    <mat-paginator [pageSize]="5" [hidePageSize]="true"></mat-paginator>
+    <mat-paginator *ngIf="hasHistory" [pageSize]="5" [hidePageSize]="true"></mat-paginator>
 </div>
 
 <ng-template #emptyBranch>
     <div class="empty-branch app-empty-state">
         <mat-icon>inventory_2</mat-icon>
         <p>暂无版本</p>
+        <span>作者发布首个版本后，用户会在这里看到推荐下载入口。</span>
     </div>
 </ng-template>

--- a/front-end/src/app/package-management/version-management/version-panel/version-panel.component.css
+++ b/front-end/src/app/package-management/version-management/version-panel/version-panel.component.css
@@ -33,9 +33,24 @@
 .section-title {
     display: inline-flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 10px;
     min-width: 0;
     color: var(--text-color);
+}
+
+.version-summary-pill {
+    display: inline-flex;
+    align-items: center;
+    min-height: 26px;
+    padding: 0 9px;
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    background: var(--surface-muted);
+    color: var(--text-muted);
+    font-size: .78rem;
+    font-weight: 800;
+    white-space: nowrap;
 }
 
 .version-tabs {

--- a/front-end/src/app/package-management/version-management/version-panel/version-panel.component.html
+++ b/front-end/src/app/package-management/version-management/version-panel/version-panel.component.html
@@ -11,6 +11,7 @@
 <div class="head app-section-header">
     <div class="section-title">
         <h2 class="app-section-title">版本</h2>
+        <span class="version-summary-pill">{{versionHealthText}}</span>
     </div>
     <span class="example-spacer"></span>
     <button *ngIf="hasEditPermission" class="action-button action-primary update-button"

--- a/front-end/src/app/package-management/version-management/version-panel/version-panel.component.ts
+++ b/front-end/src/app/package-management/version-management/version-panel/version-panel.component.ts
@@ -95,6 +95,22 @@ export class VersionPanelComponent implements OnInit {
     return this.isAuthor;
   }
 
+  get totalVersionCount(): number {
+    return this.branchs?.reduce((total, branch) => total + branch.binaries.length, 0) || 0;
+  }
+
+  get availableBranchCount(): number {
+    return this.branchs?.filter(branch => !branch.disabled).length || 0;
+  }
+
+  get versionHealthText(): string {
+    if (this.totalVersionCount === 0) {
+      return this.isAuthor ? '还没有可下载版本' : '作者暂未发布可下载版本';
+    }
+
+    return `${this.availableBranchCount} 个分支，${this.totalVersionCount} 个版本`;
+  }
+
   get isAuthor() {
     return this.package.authorId === localStorage.getItem('userId');
   }

--- a/front-end/src/app/shared/components/create-new/create-new.component.css
+++ b/front-end/src/app/shared/components/create-new/create-new.component.css
@@ -7,7 +7,7 @@
 }
 
 .create-panel {
-    width: min(100%, 480px);
+    width: min(100%, 720px);
     padding: 28px;
 }
 
@@ -79,6 +79,96 @@
     font-size: 1.15rem;
 }
 
+.creation-review small {
+    color: var(--text-muted);
+    line-height: 1.45;
+}
+
+.quality-panel {
+    display: grid;
+    grid-template-columns: minmax(0, .95fr) minmax(260px, 1.05fr);
+    gap: 16px;
+    padding: 18px;
+    border: 1px solid rgba(37, 99, 235, .16);
+    border-radius: var(--radius-lg);
+    background:
+        linear-gradient(135deg, rgba(37, 99, 235, .06), rgba(255, 255, 255, .94) 58%),
+        var(--surface);
+}
+
+.quality-panel-copy h2 {
+    margin: 0;
+    color: var(--text-color);
+    font-size: 1.22rem;
+    line-height: 1.25;
+    font-weight: 850;
+}
+
+.quality-panel-copy p {
+    margin: 8px 0 0;
+    color: var(--text-muted);
+    line-height: 1.55;
+}
+
+.quality-checklist {
+    display: grid;
+    gap: 9px;
+}
+
+.quality-check-item {
+    display: grid;
+    grid-template-columns: 30px minmax(0, 1fr) auto;
+    gap: 10px;
+    align-items: center;
+    min-width: 0;
+    padding: 10px 12px;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    background: rgba(255, 255, 255, .82);
+}
+
+.quality-check-item mat-icon {
+    display: inline-flex;
+    width: 30px;
+    height: 30px;
+    align-items: center;
+    justify-content: center;
+    border-radius: 10px;
+    background: rgba(100, 116, 139, .1);
+    color: var(--text-muted);
+    font-size: 18px;
+}
+
+.quality-check-item span {
+    min-width: 0;
+    color: var(--text-color);
+    font-weight: 750;
+    line-height: 1.35;
+}
+
+.quality-check-item small {
+    padding: 4px 8px;
+    border-radius: 999px;
+    background: var(--surface-muted);
+    color: var(--text-muted);
+    font-size: .74rem;
+    font-weight: 850;
+}
+
+.quality-check-required {
+    border-color: rgba(37, 99, 235, .2);
+}
+
+.quality-check-required mat-icon {
+    background: var(--primary-soft);
+    color: var(--primary-color);
+}
+
+.quality-check-required small {
+    background: rgba(37, 99, 235, .1);
+    color: var(--primary-strong);
+}
+
 .create-actions {
     display: flex;
     align-items: center;
@@ -133,5 +223,10 @@
 
     .create-panel {
         padding: 20px 16px;
+    }
+
+    .quality-panel {
+        grid-template-columns: 1fr;
+        padding: 14px;
     }
 }

--- a/front-end/src/app/shared/components/create-new/create-new.component.html
+++ b/front-end/src/app/shared/components/create-new/create-new.component.html
@@ -5,8 +5,8 @@
                 <mat-icon>{{this.isCreateArticle ? 'article' : 'add_box'}}</mat-icon>
             </span>
             <div>
-                <h1>创建{{this.isCreateArticle ? '文章' : '资源'}}</h1>
-                <p>{{this.isCreateArticle ? '发布新的专栏内容。' : '选择资源类别并创建新的作品页面。'}}</p>
+                <h1>{{createTitle}}</h1>
+                <p>{{createSubtitle}}</p>
             </div>
         </header>
 
@@ -42,15 +42,47 @@
                 </mat-step>
 
                 <mat-step>
+                    <ng-template matStepLabel>发布质量</ng-template>
+                    <div class="creation-step">
+                        <div class="quality-panel">
+                            <div class="quality-panel-copy">
+                                <span class="app-eyebrow">{{isCreateArticle ? '文章发布检查' : '资源发布检查'}}</span>
+                                <h2>创建后按这个顺序完善</h2>
+                                <p>{{isCreateArticle ? '文章创建后会进入详情页，正文和评论区都在那里维护。' : '资源页创建后不会一次性完成，作者工作台会继续引导截图、介绍和版本维护。'}}</p>
+                            </div>
+
+                            <div class="quality-checklist">
+                                <div *ngFor="let item of publishChecklist" class="quality-check-item"
+                                    [class.quality-check-required]="item.required">
+                                    <mat-icon>{{item.icon}}</mat-icon>
+                                    <span>{{item.text}}</span>
+                                    <small>{{item.required ? '关键' : '建议'}}</small>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="create-actions">
+                            <button type="button" mat-stroked-button matStepperPrevious>返回修改</button>
+                            <span class="example-spacer"></span>
+                            <button [disabled]="!createForm.valid" type="button" mat-flat-button color="primary" matStepperNext>
+                                预览
+                                <mat-icon>arrow_forward</mat-icon>
+                            </button>
+                        </div>
+                    </div>
+                </mat-step>
+
+                <mat-step>
                     <ng-template matStepLabel>检查并创建</ng-template>
                     <div class="creation-step">
                         <div class="creation-review">
-                            <span>{{isCreateArticle ? '文章' : selectedCategory?.text}}</span>
+                            <span>{{selectedResourceLabel}}</span>
                             <strong>{{createForm.value.name}}</strong>
+                            <small>{{isCreateArticle ? '创建后进入文章详情页继续编辑正文。' : '创建后进入资源详情页继续完善截图、介绍、标签和版本。'}}</small>
                         </div>
 
                         <div *ngIf="isCreateArticle === false" class="creation-roadmap">
-                            <strong>创建后继续完善</strong>
+                            <strong>资源上线路径</strong>
                             <div><mat-icon>image</mat-icon><span>上传截图并设置封面</span></div>
                             <div><mat-icon>description</mat-icon><span>填写资源介绍和标签</span></div>
                             <div><mat-icon>new_releases</mat-icon><span>发布首个可下载版本</span></div>

--- a/front-end/src/app/shared/components/create-new/create-new.component.ts
+++ b/front-end/src/app/shared/components/create-new/create-new.component.ts
@@ -49,6 +49,41 @@ export class CreateNewComponent implements OnInit {
 
   isCreateArticle = false;
 
+  get selectedResourceLabel(): string {
+    if (this.isCreateArticle) {
+      return '专栏文章';
+    }
+    return this.selectedCategory?.text || '未选择类别';
+  }
+
+  get createTitle(): string {
+    return this.isCreateArticle ? '创建文章' : '创建资源';
+  }
+
+  get createSubtitle(): string {
+    return this.isCreateArticle
+      ? '先写下标题，创建后进入正文编辑和发布检查。'
+      : '先建立资源页面，再按截图、介绍、标签和版本逐步完善。';
+  }
+
+  get publishChecklist() {
+    if (this.isCreateArticle) {
+      return [
+        { icon: 'title', text: '确认标题清楚具体', required: true },
+        { icon: 'edit_note', text: '进入详情页撰写正文', required: true },
+        { icon: 'visibility', text: '由作者或管理员确认公开状态', required: false },
+      ];
+    }
+
+    return [
+      { icon: 'image', text: '上传截图并把第一张设为封面', required: true },
+      { icon: 'description', text: '填写资源介绍、玩法和使用说明', required: true },
+      { icon: 'sell', text: '添加能帮助检索的标签', required: false },
+      { icon: 'new_releases', text: '发布首个可下载版本', required: true },
+      { icon: 'task_alt', text: '提交审核后再对普通用户展示', required: false },
+    ];
+  }
+
   constructor(
     private dialog: MatDialog,
     private san11pkService: San11PlatformServiceService,

--- a/front-end/src/app/shared/components/dashboards/dashboard/dashboard.component.html
+++ b/front-end/src/app/shared/components/dashboards/dashboard/dashboard.component.html
@@ -4,9 +4,10 @@
             <div class="catalog-title-row">
                 <span class="catalog-kicker">资源库</span>
                 <span class="catalog-summary app-count-pill" *ngIf="packages != undefined">{{packages.length}} 项资源</span>
+                <span class="catalog-summary app-count-pill" *ngIf="currentTagId">标签筛选</span>
             </div>
-            <h1>San11 工具与 MOD</h1>
-            <p>按分类、标签和热度快速找到可用资源。</p>
+            <h1>{{catalogHeading}}</h1>
+            <p>{{catalogDescription}}</p>
         </div>
 
         <div class="dashboard-actions" *ngIf="listRequest">
@@ -27,7 +28,7 @@
 
     <div *ngIf="packages?.length === 0" class="dashboard-placeholder app-empty-state">
         <mat-icon>inventory_2</mat-icon>
-        <p>{{listRequest?.filter ? '当前筛选条件下没有资源' : '这里还没有资源'}}</p>
+        <p>{{emptyStateText}}</p>
         <button *ngIf="listRequest?.filter" mat-stroked-button color="primary" type="button" (click)="clearFilter()">
             清除筛选
         </button>

--- a/front-end/src/app/shared/components/dashboards/dashboard/dashboard.component.ts
+++ b/front-end/src/app/shared/components/dashboards/dashboard/dashboard.component.ts
@@ -30,6 +30,9 @@ export class DashboardComponent implements OnInit {
     { value: 'download_count DESC', viewValue: '下载量' },
   ];
   selectedOrder = this.orderOptions[0].value;
+  currentQuery = '';
+  currentCategoryId = '';
+  currentTagId = '';
 
   constructor(
     private notificationService: NotificationService,
@@ -55,6 +58,9 @@ export class DashboardComponent implements OnInit {
         const tagId = ap.qparams['tagId'];
         const query = ap.qparams['query']
         const userId = ap.parentParams.userId;
+        this.currentQuery = query || '';
+        this.currentCategoryId = categoryId || '';
+        this.currentTagId = tagId || '';
 
         if (query != undefined) {
           this.searchPackages(query);
@@ -140,5 +146,38 @@ export class DashboardComponent implements OnInit {
       queryParams: { tagId: null },
       queryParamsHandling: 'merge',
     });
+  }
+
+  get catalogHeading(): string {
+    if (this.currentQuery) {
+      return `搜索：${this.currentQuery}`;
+    }
+
+    const category = GlobalConstants.categories.find(item => item.value === this.currentCategoryId);
+    return category ? category.text : 'San11 工具与 MOD';
+  }
+
+  get catalogDescription(): string {
+    if (this.currentQuery) {
+      return '按名称和资源标识匹配结果，继续使用左侧分类和排序缩小范围。';
+    }
+
+    if (this.currentTagId) {
+      return '当前正在查看标签筛选结果。';
+    }
+
+    return '按分类、标签和热度快速找到可用资源。';
+  }
+
+  get emptyStateText(): string {
+    if (this.currentQuery) {
+      return '没有找到匹配的资源';
+    }
+
+    if (this.listRequest?.filter) {
+      return '当前筛选条件下没有资源';
+    }
+
+    return '这里还没有资源';
   }
 }

--- a/front-end/src/app/shared/components/discussion/discussion.component.css
+++ b/front-end/src/app/shared/components/discussion/discussion.component.css
@@ -33,6 +33,13 @@
     font-weight: 800;
 }
 
+.caption p {
+    margin: 4px 0 0;
+    color: var(--text-muted);
+    font-size: .86rem;
+    line-height: 1.35;
+}
+
 .create-thread-button {
     min-height: 38px;
     border-radius: 999px;
@@ -41,6 +48,44 @@
 
 .thread-list {
     background: var(--surface);
+}
+
+.discussion-mode-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    overflow-x: auto;
+    padding: 12px 18px;
+    border-bottom: 1px solid var(--border-color);
+    background: rgba(248, 250, 252, .72);
+}
+
+.discussion-mode-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-height: 34px;
+    flex: 0 0 auto;
+    padding: 0 11px;
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    background: var(--surface);
+    color: var(--text-muted);
+    font: inherit;
+    font-size: .84rem;
+    font-weight: 800;
+}
+
+.discussion-mode-chip mat-icon {
+    width: 17px;
+    height: 17px;
+    font-size: 17px;
+}
+
+.discussion-mode-chip-active {
+    border-color: rgba(37, 99, 235, .24);
+    background: rgba(37, 99, 235, .08);
+    color: var(--primary-strong);
 }
 
 .thread-loading {
@@ -80,6 +125,11 @@ mat-paginator {
     min-height: 12rem;
 }
 
+.dashboard-placeholder span {
+    color: var(--text-muted);
+    font-size: .9rem;
+}
+
 @media (max-width: 40rem) {
     .main-container {
         padding: .75rem 0 1.5rem;
@@ -88,6 +138,10 @@ mat-paginator {
     .caption {
         min-height: 68px;
         padding: 0 14px;
+    }
+
+    .caption p {
+        display: none;
     }
 
     .thread-loading-row {

--- a/front-end/src/app/shared/components/discussion/discussion.component.html
+++ b/front-end/src/app/shared/components/discussion/discussion.component.html
@@ -5,6 +5,7 @@
                 <h3>
                     {{this.displayName}}
                 </h3>
+                <p>反馈问题、记录建议和跟进资源更新。</p>
             </div>
             <span class="example-spacer"></span>
             <button mat-flat-button color="primary" class="create-thread-button" matTooltip="新帖子"
@@ -12,6 +13,14 @@
                 <mat-icon>add</mat-icon>
                 <span>新帖子</span>
             </button>
+        </div>
+
+        <div class="discussion-mode-row">
+            <span *ngFor="let mode of discussionModes; let first = first"
+                class="discussion-mode-chip" [class.discussion-mode-chip-active]="first">
+                <mat-icon>{{mode.icon}}</mat-icon>
+                <span>{{mode.label}}</span>
+            </span>
         </div>
 
         <div *ngIf="isLoading" class="thread-loading">
@@ -32,6 +41,7 @@
         <div *ngIf="!isLoading && threads?.length === 0" class="dashboard-placeholder app-empty-state">
             <mat-icon>forum</mat-icon>
             <p>暂无讨论</p>
+            <span>可以发起问题反馈、使用建议或版本更新讨论。</span>
         </div>
 
         <mat-paginator *ngIf="!isLoading && threads?.length > 0" [length]="totalThreadsCount" [pageSize]="pageSize" [hidePageSize]="true"

--- a/front-end/src/app/shared/components/discussion/discussion.component.ts
+++ b/front-end/src/app/shared/components/discussion/discussion.component.ts
@@ -24,6 +24,12 @@ export class DiscussionComponent implements OnInit {
   totalThreadsCount = 200;
   reachedEnd = false;
   isLoading = false;
+  discussionModes = [
+    { label: '全部讨论', icon: 'forum' },
+    { label: '问题反馈', icon: 'help_outline' },
+    { label: '建议想法', icon: 'tips_and_updates' },
+    { label: '更新反馈', icon: 'new_releases' },
+  ];
 
   constructor(
     private elementRef: ElementRef,

--- a/front-end/src/app/user/published-packages/published-packages.component.css
+++ b/front-end/src/app/user/published-packages/published-packages.component.css
@@ -2,11 +2,81 @@
     margin-top: 16px;
 }
 
-.package-name {
+.published-header h2 {
+    margin: 0;
     color: var(--text-color);
+    font-size: 1.05rem;
     font-weight: 800;
 }
 
-.package-name:hover {
+.published-header p {
+    margin: 4px 0 0;
+    color: var(--text-muted);
+    font-size: .88rem;
+}
+
+.package-name-cell {
+    display: grid;
+    gap: 3px;
+    min-width: 220px;
+    color: var(--text-color);
+    cursor: pointer;
+}
+
+.package-name-cell strong,
+.package-name-cell small {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.package-name-cell strong {
+    font-weight: 850;
+}
+
+.package-name-cell small {
+    color: var(--text-muted);
+    font-size: .8rem;
+}
+
+.package-name-cell:hover strong {
     color: var(--primary-color);
+}
+
+.status-pill {
+    display: inline-flex;
+    align-items: center;
+    min-height: 28px;
+    padding: 0 9px;
+    border-radius: 999px;
+    background: var(--surface-muted);
+    color: var(--text-muted);
+    font-size: .78rem;
+    font-weight: 850;
+    white-space: nowrap;
+}
+
+.status-pill-normal {
+    background: rgba(5, 150, 105, .1);
+    color: #047857;
+}
+
+.status-pill-review {
+    background: rgba(245, 158, 11, .14);
+    color: var(--warning-color);
+}
+
+.status-pill-hidden,
+.status-pill-default {
+    background: rgba(100, 116, 139, .12);
+    color: var(--text-muted);
+}
+
+.status-pill-danger {
+    background: rgba(220, 38, 38, .1);
+    color: var(--accent-color);
+}
+
+.published-empty {
+    margin: 16px;
 }

--- a/front-end/src/app/user/published-packages/published-packages.component.html
+++ b/front-end/src/app/user/published-packages/published-packages.component.html
@@ -1,4 +1,11 @@
 <div class="published-packages-panel app-list-panel">
+<div class="published-header app-list-header">
+    <div>
+        <h2>作品维护</h2>
+        <p>检查资源状态、资料完整度和最近更新。</p>
+    </div>
+    <span class="app-count-pill">{{publishedPackages.length}} 项资源</span>
+</div>
 <table mat-table [dataSource]="dataSource" class="table app-data-table">
 
     <!--- Note that these columns can be defined in any order.
@@ -6,16 +13,32 @@
 
     <!-- name Column -->
     <ng-container matColumnDef="name">
-        <th mat-header-cell *matHeaderCellDef> 工具 </th>
-        <td mat-cell *matCellDef="let package" class="package-name clickable muted-cell" (click)="onPackageClick(package)">
-            {{package.name}}
+        <th mat-header-cell *matHeaderCellDef> 资源 </th>
+        <td mat-cell *matCellDef="let package" class="package-name-cell" (click)="onPackageClick(package)">
+            <strong>{{package.packageName}}</strong>
+            <small>{{package.name}}</small>
         </td>
     </ng-container>
 
-    <!-- createTime Column -->
-    <ng-container matColumnDef="createTime">
-        <th mat-header-cell *matHeaderCellDef> 创建于 </th>
-        <td mat-cell *matCellDef="let package" class="muted-cell"> {{package.createTime}} </td>
+    <ng-container matColumnDef="status">
+        <th mat-header-cell *matHeaderCellDef> 状态 </th>
+        <td mat-cell *matCellDef="let package">
+            <span class="status-pill" [ngClass]="'status-pill-' + stateTone(package)">
+                {{stateLabel(package)}}
+            </span>
+        </td>
+    </ng-container>
+
+    <ng-container matColumnDef="maintenance">
+        <th mat-header-cell *matHeaderCellDef> 维护提示 </th>
+        <td mat-cell *matCellDef="let package" class="muted-cell">
+            {{maintenanceText(package)}}
+        </td>
+    </ng-container>
+
+    <ng-container matColumnDef="updateTime">
+        <th mat-header-cell *matHeaderCellDef> 最近更新 </th>
+        <td mat-cell *matCellDef="let package" class="muted-cell"> {{package.updateTime || package.createTime}} </td>
     </ng-container>
 
     <!-- downloadCount Column -->
@@ -27,5 +50,9 @@
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
     <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
 </table>
+<div *ngIf="publishedPackages.length === 0" class="app-empty-state published-empty">
+    <mat-icon>inventory_2</mat-icon>
+    <p>还没有发布资源</p>
+</div>
 <mat-paginator [pageSizeOptions]="[10]"></mat-paginator>
 </div>

--- a/front-end/src/app/user/published-packages/published-packages.component.ts
+++ b/front-end/src/app/user/published-packages/published-packages.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, ViewChild } from '@angular/core';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Package } from '../../../proto/san11-platform.pb';
+import { Package, ResourceState } from '../../../proto/san11-platform.pb';
 import { NotificationService } from '../../common/notification.service';
 import { San11PlatformServiceService } from '../../service/san11-platform-service.service';
 import { GlobalConstants } from '../../common/global-constants';
@@ -17,7 +17,7 @@ export class PublishedPackagesComponent implements OnInit {
   @ViewChild(MatPaginator) paginator: MatPaginator;
   userId: string;
 
-  displayedColumns: string[] = ['name', 'createTime', 'downloadCount'];
+  displayedColumns: string[] = ['name', 'status', 'maintenance', 'updateTime', 'downloadCount'];
   dataSource: MatTableDataSource<Package>;
   publishedPackages: Package[] = [];
   constructor(
@@ -56,5 +56,54 @@ export class PublishedPackagesComponent implements OnInit {
 
   onPackageClick(san11Package: Package) {
     this.router.navigate(san11Package.name.split('/'));
+  }
+
+  stateLabel(san11Package: Package): string {
+    switch (san11Package.state) {
+      case ResourceState.NORMAL:
+        return '正常展示';
+      case ResourceState.UNDER_REVIEW:
+        return '待审核';
+      case ResourceState.HIDDEN:
+        return '已隐藏';
+      case ResourceState.DELETED:
+        return '已删除';
+      default:
+        return '未知状态';
+    }
+  }
+
+  stateTone(san11Package: Package): string {
+    switch (san11Package.state) {
+      case ResourceState.NORMAL:
+        return 'normal';
+      case ResourceState.UNDER_REVIEW:
+        return 'review';
+      case ResourceState.HIDDEN:
+        return 'hidden';
+      case ResourceState.DELETED:
+        return 'danger';
+      default:
+        return 'default';
+    }
+  }
+
+  maintenanceItems(san11Package: Package): string[] {
+    const items: string[] = [];
+    if (!san11Package.imageUrls?.length) {
+      items.push('缺截图');
+    }
+    if (!san11Package.description || san11Package.description.trim().length < 80) {
+      items.push('介绍偏短');
+    }
+    if (!san11Package.tags?.length) {
+      items.push('缺标签');
+    }
+    return items;
+  }
+
+  maintenanceText(san11Package: Package): string {
+    const items = this.maintenanceItems(san11Package);
+    return items.length === 0 ? '资料完整' : items.join('、');
   }
 }

--- a/front-end/src/app/website-management/admin-message-board/admin-message-board.component.css
+++ b/front-end/src/app/website-management/admin-message-board/admin-message-board.component.css
@@ -342,7 +342,7 @@
 
 .review-item {
     display: grid;
-    grid-template-columns: auto minmax(0, 1fr) auto auto;
+    grid-template-columns: 38px minmax(0, 1fr) auto auto;
     align-items: center;
     gap: 10px;
     width: 100%;
@@ -361,16 +361,54 @@
     background: rgba(37, 99, 235, .04);
 }
 
-.review-item span {
+.review-item-icon {
+    display: inline-flex;
+    width: 38px;
+    height: 38px;
+    align-items: center;
+    justify-content: center;
+    border-radius: 12px;
+    background: rgba(245, 158, 11, .12);
+    color: var(--warning-color);
+}
+
+.review-item-icon mat-icon {
+    width: 20px;
+    height: 20px;
+    font-size: 20px;
+}
+
+.review-item-copy {
+    display: grid;
+    gap: 3px;
+    min-width: 0;
+}
+
+.review-item-copy strong,
+.review-item-copy small {
     min-width: 0;
     overflow: hidden;
-    font-weight: 800;
     text-overflow: ellipsis;
     white-space: nowrap;
 }
 
-.review-item small {
+.review-item-copy strong {
+    color: var(--text-color);
+    font-weight: 850;
+}
+
+.review-item-copy small {
     color: var(--text-muted);
+}
+
+.review-item-status {
+    padding: 5px 9px;
+    border-radius: 999px;
+    background: rgba(245, 158, 11, .12);
+    color: var(--warning-color);
+    font-size: .76rem;
+    font-weight: 850;
+    white-space: nowrap;
 }
 
 .compact-empty-state {

--- a/front-end/src/app/website-management/admin-message-board/admin-message-board.component.html
+++ b/front-end/src/app/website-management/admin-message-board/admin-message-board.component.html
@@ -1,11 +1,17 @@
 <div class="admin-page">
     <section class="admin-header">
         <div>
-            <h1>站点动态</h1>
-            <p>按资源、社交、通知和下载类型查看最近平台活动。</p>
+            <span class="app-eyebrow">管理工作台</span>
+            <h1>审核与站点动态</h1>
+            <p>优先处理待审核资源，再按资源、社交、通知和下载类型查看最近平台活动。</p>
         </div>
 
         <div class="summary-grid">
+            <div class="summary-item">
+                <mat-icon>pending_actions</mat-icon>
+                <span>待审</span>
+                <strong>{{pendingReviews.length}}</strong>
+            </div>
             <div class="summary-item">
                 <mat-icon>inventory_2</mat-icon>
                 <span>资源</span>
@@ -21,28 +27,28 @@
                 <span>通知</span>
                 <strong>{{notifications.length}}</strong>
             </div>
-            <div class="summary-item">
-                <mat-icon>download</mat-icon>
-                <span>下载</span>
-                <strong>{{downloads.length}}</strong>
-            </div>
         </div>
     </section>
 
     <section class="review-queue surface-panel">
         <div class="panel-header">
             <div>
-                <h2>待处理</h2>
-                <p>需要管理员审核的新资源</p>
+                <h2>审核队列</h2>
+                <p>{{pendingReviewSummary}}</p>
             </div>
             <span>{{pendingReviews.length}} 项</span>
         </div>
         <div *ngIf="pendingReviews.length; else noPendingReviews" class="review-grid">
             <button *ngFor="let package of pendingReviews" type="button" class="review-item"
                 (click)="openPackage(package)">
-                <mat-icon>pending_actions</mat-icon>
-                <span>{{package.packageName}}</span>
-                <small>{{package.name}}</small>
+                <span class="review-item-icon">
+                    <mat-icon>pending_actions</mat-icon>
+                </span>
+                <span class="review-item-copy">
+                    <strong>{{package.packageName}}</strong>
+                    <small>{{packageCategoryName(package)}} · {{package.name}}</small>
+                </span>
+                <span class="review-item-status">待审核</span>
                 <mat-icon>chevron_right</mat-icon>
             </button>
         </div>

--- a/front-end/src/app/website-management/admin-message-board/admin-message-board.component.ts
+++ b/front-end/src/app/website-management/admin-message-board/admin-message-board.component.ts
@@ -58,6 +58,23 @@ export class AdminMessageBoardComponent implements OnInit {
     this.router.navigate(san11Package.name.split('/'));
   }
 
+  get adminTotalActivityCount(): number {
+    return this.resourceChanges.length + this.socialActivaties.length + this.notifications.length + this.downloads.length;
+  }
+
+  get pendingReviewSummary(): string {
+    if (this.pendingReviews.length === 0) {
+      return '审核队列为空';
+    }
+
+    return `${this.pendingReviews.length} 个资源等待审核`;
+  }
+
+  packageCategoryName(san11Package: Package): string {
+    const categoryId = san11Package.name?.split('/')?.[1];
+    return GlobalConstants.categories.find(category => category.value === categoryId)?.text || '资源';
+  }
+
   load_activities() {
     this.progressService.loading();
 

--- a/front-end/src/environments/environment.autopush.ts
+++ b/front-end/src/environments/environment.autopush.ts
@@ -5,4 +5,5 @@ export const environment = {
   domain: 'localhost',
   schema: 'https',
   serverPort: 8090,
+  devAccounts: [],
 };

--- a/front-end/src/environments/environment.prod.ts
+++ b/front-end/src/environments/environment.prod.ts
@@ -3,4 +3,5 @@ export const environment = {
   domain: 'san11pk.org',
   schema: 'https',
   serverPort: 8090,
+  devAccounts: [],
 };

--- a/front-end/src/environments/environment.staging.ts
+++ b/front-end/src/environments/environment.staging.ts
@@ -5,4 +5,5 @@ export const environment = {
   domain: 'staging.san11pk.org',
   schema: 'https',
   serverPort: 8090,
+  devAccounts: [],
 };

--- a/front-end/src/environments/environment.ts
+++ b/front-end/src/environments/environment.ts
@@ -7,6 +7,26 @@ export const environment = {
   domain: 'localhost',
   schema: 'http',
   serverPort: 8091,
+  devAccounts: [
+    {
+      label: '管理员',
+      identity: 'dev_admin',
+      password: 'devpass',
+      note: '审核、隐藏、恢复和管理后台',
+    },
+    {
+      label: '作者',
+      identity: 'dev_author',
+      password: 'devpass',
+      note: '资源编辑、截图、版本和作者工具',
+    },
+    {
+      label: '普通用户',
+      identity: 'dev_user',
+      password: 'devpass',
+      note: '收藏、评论和普通浏览',
+    },
+  ],
 };
 
 


### PR DESCRIPTION
## Summary
- Upgrade core frontend workflows: resource creation guidance, recommended version cards, resource health, author maintenance, admin review queue, catalog context, and discussion affordances.
- Seed deterministic DEV accounts for admin, package author, and regular user, plus a seeded author-owned package.
- Add dev-only quick-fill account buttons on the sign-in page and document the credentials in README.

## CI behavior
This PR should trigger backend tests, frontend production build, gateway tests, UI Playwright E2E, and production image build. The production deployment job is guarded by push-to-main only and should not run for this PR.

## Verification
- PYTHONPATH=back-end/src back-end/.venv/bin/python -m unittest back-end/src/app/dev_seed_test.py
- npm run build
- git diff --check
- Browser test via Playwright: verified dev_admin, dev_author, and dev_user login flows and role-specific pages.